### PR TITLE
feat: use caps word

### DIFF
--- a/keyboards/crkbd/rev1/keymaps/bpg/config.h
+++ b/keyboards/crkbd/rev1/keymaps/bpg/config.h
@@ -21,9 +21,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #pragma once
 
 #define MASTER_RIGHT
-#define TAPPING_TERM 200
-#define TAPPING_FORCE_HOLD
-#define PERMISSIVE_HOLD
+#define TAPPING_TERM 175
 #define CHORDAL_HOLD
 
 #ifdef RGBLIGHT_ENABLE

--- a/keyboards/crkbd/rev1/keymaps/bpg/config.h
+++ b/keyboards/crkbd/rev1/keymaps/bpg/config.h
@@ -24,6 +24,8 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #define TAPPING_TERM 175
 #define CHORDAL_HOLD
 
+#define BOTH_SHIFTS_TURNS_ON_CAPS_WORD
+
 #ifdef RGBLIGHT_ENABLE
   #define RGBLIGHT_EFFECT_RAINBOW_SWIRL
   #define RGBLIGHT_LIMIT_VAL 120

--- a/keyboards/crkbd/rev1/keymaps/bpg/keymap.c
+++ b/keyboards/crkbd/rev1/keymaps/bpg/keymap.c
@@ -57,7 +57,7 @@ const uint16_t PROGMEM keymaps[][MATRIX_ROWS][MATRIX_COLS] = {
   //|--------+--------+--------+--------+--------+--------|                    |--------+--------+--------+--------+--------+--------|
      KC_QUOT,  ALT_A,   CTL_O,   SFT_E,   GUI_U,   KC_I,                           KC_D,   GUI_H,   SHFT_T,  CTL_N,  ALT_S,  KC_MINS,
   //|--------+--------+--------+--------+--------+--------|                    |--------+--------+--------+--------+--------+--------|
-      SC_LSPO,  KC_AT,   KC_Q,    KC_J,    KC_K,   KC_X,                            KC_B,    KC_M,    KC_W,    KC_V,    KC_Z,  SC_RSPC,
+     KC_LPRN,  KC_AT,   KC_Q,    KC_J,    KC_K,   KC_X,                            KC_B,    KC_M,    KC_W,    KC_V,    KC_Z,  KC_RPRN,
   //|--------+--------+--------+--------+--------+--------+--------|  |--------+--------+--------+--------+--------+--------+--------|
      LT(_MEDIA, KC_ESC), LT(_NAV, KC_ENT), LT(_BUTTON, KC_TAB),                LT(_SYMBOL, KC_BSPC), LT(_NUM, KC_SPC), LT(_FUNCTION, KC_DEL)
                                       //`--------------------------'  `--------------------------'

--- a/keyboards/crkbd/rev1/keymaps/bpg/keymap.c
+++ b/keyboards/crkbd/rev1/keymaps/bpg/keymap.c
@@ -91,7 +91,7 @@ const uint16_t PROGMEM keymaps[][MATRIX_ROWS][MATRIX_COLS] = {
   //,-----------------------------------------------------.                    ,-----------------------------------------------------.
       XXXXXXX, XXXXXXX, XXXXXXX, XXXXXXX, XXXXXXX, XXXXXXX,                     XXXXXXX, XXXXXXX, XXXXXXX, XXXXXXX, XXXXXXX, XXXXXXX,
   //|--------+--------+--------+--------+--------+--------|                    |--------+--------+--------+--------+--------+--------|
-      XXXXXXX, XXXXXXX, XXXXXXX, XXXXXXX, XXXXXXX, XXXXXXX,                      XXXXXXX, XXXXXXX, RGB_TOG,  XXXXXXX, XXXXXXX, XXXXXXX,
+      XXXXXXX, XXXXXXX, XXXXXXX, XXXXXXX, XXXXXXX, XXXXXXX,                      XXXXXXX, XXXXXXX, RM_TOGG,  XXXXXXX, XXXXXXX, XXXXXXX,
   //|--------+--------+--------+--------+--------+--------|                    |--------+--------+--------+--------+--------+--------|
       XXXXXXX, XXXXXXX, XXXXXXX, XXXXXXX, XXXXXXX, XXXXXXX,                      XXXXXXX, XXXXXXX, XXXXXXX, XXXXXXX, XXXXXXX, XXXXXXX,
   //|--------+--------+--------+--------+--------+--------+--------|  |--------+--------+--------+--------+--------+--------+--------|

--- a/keyboards/crkbd/rev1/keymaps/bpg/rules.mk
+++ b/keyboards/crkbd/rev1/keymaps/bpg/rules.mk
@@ -1,0 +1,1 @@
+CAPS_WORD_ENABLE = yes


### PR DESCRIPTION
Try caps word instead of space cadet shift. In future iterations, the paren keys will be improved upon